### PR TITLE
feat: 공용 버튼 컴포넌트 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,5 +39,6 @@ module.exports = {
     'react/jsx-fragments': 'off',
     'no-unused-vars': 'warn',
     'no-console': 'warn',
+    'react/button-has-type': 'off',
   },
 };

--- a/src/shared/ui/Button.jsx
+++ b/src/shared/ui/Button.jsx
@@ -1,0 +1,22 @@
+import styles from './Button.module.scss';
+
+const Button = ({
+  type = 'button',
+  className = '',
+  disabled = false,
+  children,
+  onClick = () => {},
+}) => {
+  return (
+    <button
+      className={`${styles.button} ${className}`}
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/shared/ui/Button.module.scss
+++ b/src/shared/ui/Button.module.scss
@@ -1,0 +1,12 @@
+.button {
+  background: linear-gradient(45deg, variables.$orange, variables.$pink);
+  border-radius: 3px;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 26px;
+  color: #ffffff;
+}
+
+.button:disabled {
+  background: variables.$gray;
+}


### PR DESCRIPTION
## 요구사항
- [x] 모든 페이지에서 사용할 수 있는 공용 버튼 컴포넌트 구현
## 변경 사항
## 이슈
사용하실때 버튼 텍스트 기준으로 상하좌우 padding 값만 className prop으로 내려서 사용하시면 됩니다.
## 스크린샷
![button](https://github.com/user-attachments/assets/8c366213-ea3d-4fe0-a380-130a4606fb1e)
