### PR TITLE
feat: 아이돌 리스트 컴포넌트 구현

### DIFF
--- a/src/entities/listApi.js
+++ b/src/entities/listApi.js
@@ -1,0 +1,9 @@
+export async function getIdols(gender) {
+  const response = await fetch(
+    `https://fandom-k-api.vercel.app/10-3/charts/{gender}?gender=${gender}&pageSize=10`
+  );
+  const body = await response.json();
+  return body;
+}
+
+export default getIdols;

--- a/src/shared/ui/idolchart/IdolChartList.jsx
+++ b/src/shared/ui/idolchart/IdolChartList.jsx
@@ -1,0 +1,35 @@
+import './IdolChartList.scss';
+import IdolProfileWrapper from './idollistcomponents/IdolProfileWrapper';
+import IdolInfo from './idollistcomponents/IdolInfo';
+
+const IdolListItem = ({ item }) => {
+  const { name, group, profilePicture, rank, totalVotes } = item;
+
+  return (
+    <div className="idolListItem">
+      <div className="idolFirstSection">
+        <IdolProfileWrapper profilePicture={profilePicture} name={name} />
+        <IdolInfo rank={rank} />
+        <div className="idolGandN">
+          <IdolInfo group={group} />
+          <IdolInfo name={name} />
+        </div>
+      </div>
+      <div className="idolVote">{totalVotes}표</div>
+    </div>
+  );
+};
+
+const IdolList = ({ items = [] }) => {
+  return (
+    <ul className="idolList">
+      {items.map((item) => (
+        <li key={item.id}>
+          <IdolListItem item={item} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default IdolList;

--- a/src/shared/ui/idolchart/IdolChartList.scss
+++ b/src/shared/ui/idolchart/IdolChartList.scss
@@ -1,0 +1,31 @@
+@import '@/assets/styles/variables';
+.idolList {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  padding: 0;
+  gap: 15px;
+  margin: 10px;
+}
+
+.idolListItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px;
+}
+
+.idolFirstSection {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+
+.idolGandN {
+  display: flex;
+  gap: 3px;
+}
+
+.idolVote {
+  color: $light-gray;
+}

--- a/src/shared/ui/idolchart/idollistcomponents/IdolImage.jsx
+++ b/src/shared/ui/idolchart/idollistcomponents/IdolImage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const IdolImage = ({ profilePicture, name }) => {
+  return <img src={profilePicture} alt={name} className="idolProfile" />;
+};
+
+export default IdolImage;

--- a/src/shared/ui/idolchart/idollistcomponents/IdolInfo.jsx
+++ b/src/shared/ui/idolchart/idollistcomponents/IdolInfo.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import './IdolInfo.scss';
+
+const IdolInfo = ({ rank, name, group }) => {
+  return (
+    <div className="idolInfo">
+      <div className="idolRank">{rank}</div>
+      <div className="idolGroup">{group}</div>
+      <div className="idolName">{name}</div>
+    </div>
+  );
+};
+
+export default IdolInfo;

--- a/src/shared/ui/idolchart/idollistcomponents/IdolInfo.scss
+++ b/src/shared/ui/idolchart/idollistcomponents/IdolInfo.scss
@@ -1,0 +1,10 @@
+@import '@/assets/styles/variables';
+
+.idolName,
+.idolGroup {
+  color: $white;
+}
+
+.idolRank {
+  color: $orange;
+}

--- a/src/shared/ui/idolchart/idollistcomponents/IdolProfileWrapper.jsx
+++ b/src/shared/ui/idolchart/idollistcomponents/IdolProfileWrapper.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './IdolProfileWrapper.scss';
+
+const IdolProfileWrapper = ({ profilePicture, name }) => {
+  return (
+    <div className="idolProfileWrapper">
+      <img src={profilePicture} alt={name} className="idolProfile" />
+    </div>
+  );
+};
+
+export default IdolProfileWrapper;

--- a/src/shared/ui/idolchart/idollistcomponents/IdolProfileWrapper.scss
+++ b/src/shared/ui/idolchart/idollistcomponents/IdolProfileWrapper.scss
@@ -1,0 +1,17 @@
+@import '@/assets/styles/variables';
+
+.idolProfileWrapper {
+  width: 60px;
+  height: 60px;
+  border-radius: 70%;
+  overflow: hidden;
+  border: 1px solid $pink;
+  padding: 1px;
+}
+
+.idolProfile {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## 요구사항
- [x] mypage와 chart에서 사용할 수 있는 동그란 프로필 사진 및 정보 구현
## 이슈
리스트 형태로 투표 창에서 사용되는 것 같아 올려두었습니다. 뒤쪽의 투표값 제거하고 투표버튼 넣으시면 될 것 같습니다.
## 스크린샷
<img width="146" alt="스크린샷 2024-09-26 오후 10 29 18" src="https://github.com/user-attachments/assets/08fc2774-ed35-4962-9233-23febe3c1b92">
<img width="722" alt="스크린샷 2024-09-26 오후 10 29 24" src="https://github.com/user-attachments/assets/1f2ccd20-09f4-41db-ae4c-4bb322552cff">
