### PR TITLE
feat: CardList 컴포넌트 구현

### DIFF
--- a/src/features/support/CardList.jsx
+++ b/src/features/support/CardList.jsx
@@ -1,0 +1,172 @@
+import { useRef, useEffect, useCallback, useMemo } from 'react';
+import Card from '@/shared/ui/Card';
+import leftIcon from '@/assets/images/btn-pagination-left.svg';
+import rightIcon from '@/assets/images/btn-pagination-right.svg';
+import useCarouselStore from './useCarouselStore';
+import styles from './CardList.module.scss';
+
+const CardList = ({ supports }) => {
+  const carouselRef = useRef(null);
+  const {
+    currentIndex,
+    setCurrentIndex,
+    slidesToShow,
+    setSlidesToShow,
+    translateX,
+    setTranslateX,
+    startX,
+    setStartX,
+    initialPosition,
+    setInitialPosition,
+    isDragging,
+    setIsDragging,
+    itemWidth,
+    setItemWidth,
+  } = useCarouselStore();
+
+  const maxIndex = useMemo(() => {
+    return supports.length - slidesToShow;
+  }, [supports.length, slidesToShow]);
+
+  const caculateTranslateX = useCallback(
+    (index) => -index * itemWidth,
+    [itemWidth]
+  );
+
+  const handleResize = useCallback(() => {
+    const screenWidth = window.innerWidth;
+    const nextItemWidth = screenWidth < 768 ? 160 : 300;
+    setItemWidth(nextItemWidth);
+
+    const visibleSlides = Math.round(
+      carouselRef.current
+        ? carouselRef.current.parentElement.clientWidth / itemWidth
+        : 4
+    );
+    setSlidesToShow(visibleSlides);
+    setTranslateX(caculateTranslateX(currentIndex));
+  }, [
+    currentIndex,
+    setTranslateX,
+    caculateTranslateX,
+    setItemWidth,
+    itemWidth,
+    setSlidesToShow,
+  ]);
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [handleResize]);
+
+  const handleStart = (clientX) => {
+    setStartX(clientX);
+    setInitialPosition(translateX);
+    carouselRef.current.style.transition = 'none';
+    setIsDragging(true);
+  };
+
+  const handleMove = (clientX) => {
+    if (!isDragging) return;
+    const movement = clientX - startX;
+    const newTranslateX = initialPosition + movement;
+
+    setTranslateX(newTranslateX);
+    carouselRef.current.style.transform = `translateX(${newTranslateX}px)`;
+  };
+
+  const handleEnd = (clientX) => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    carouselRef.current.style.transition = 'transform 0.3s ease-in-out';
+
+    const maxTranslateX = -(
+      carouselRef.current.scrollWidth -
+      carouselRef.current.parentElement.clientWidth
+    );
+    const movement = clientX - startX;
+    const threshold = itemWidth / 4;
+
+    if (translateX > 0) {
+      setCurrentIndex(0);
+      setTranslateX(0);
+    } else if (translateX - threshold < maxTranslateX) {
+      setCurrentIndex(maxIndex);
+      setTranslateX(maxTranslateX);
+    } else if (movement < -threshold && currentIndex <= maxIndex) {
+      setCurrentIndex(currentIndex + 1);
+      setTranslateX(caculateTranslateX(currentIndex + 1));
+    } else if (movement > threshold && currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+      setTranslateX(caculateTranslateX(currentIndex - 1));
+    } else {
+      setTranslateX(caculateTranslateX(currentIndex));
+    }
+
+    carouselRef.current.style.transform = `translateX(${translateX}px)`;
+  };
+
+  const handleButton = (index) => {
+    setCurrentIndex(index);
+    setTranslateX(caculateTranslateX(index));
+  };
+
+  const handleTouchStart = (e) =>
+    handleStart(e.clientX || e.touches[0].clientX);
+  const handleTouchMove = (e) => handleMove(e.clientX || e.touches[0].clientX);
+  const handleTouchEnd = (e) =>
+    handleEnd(e.clientX || e.changedTouches[0].clientX);
+
+  return supports.length ? (
+    <div className={styles.wrapper}>
+      <button
+        className={`${styles.button} ${styles.left}`}
+        onClick={() => handleButton(currentIndex - 1)}
+        disabled={currentIndex === 0}
+      >
+        <img src={leftIcon} alt="이전 슬라이드" />
+      </button>
+      <div className={styles.container}>
+        <ul
+          className={styles.cardList}
+          ref={carouselRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onMouseDown={handleTouchStart}
+          onMouseMove={isDragging ? handleTouchMove : null}
+          onMouseUp={handleTouchEnd}
+          onMouseLeave={handleTouchEnd}
+          role="listbox"
+          style={{ transform: `translateX(${translateX}px)` }}
+        >
+          {supports.map(
+            ({ id, idol, title, subtitle, targetDonation, deadline }) => {
+              return (
+                <li key={id} className={styles.card}>
+                  <Card
+                    idolImg={idol.profilePicture}
+                    title={title}
+                    subtitle={subtitle}
+                    received={targetDonation.toLocaleString()}
+                    deadline={deadline}
+                  />
+                </li>
+              );
+            }
+          )}
+        </ul>
+      </div>
+      <button
+        className={`${styles.button} ${styles.right}`}
+        onClick={() => handleButton(currentIndex + 1)}
+        disabled={currentIndex === maxIndex}
+      >
+        <img src={rightIcon} alt="다음 슬라이드" />
+      </button>
+    </div>
+  ) : null;
+};
+
+export default CardList;

--- a/src/features/support/CardList.module.scss
+++ b/src/features/support/CardList.module.scss
@@ -1,0 +1,52 @@
+.wrapper {
+  position: relative;
+  max-width: 1200px;
+}
+
+.container {
+  width: 100%;
+  overflow: hidden;
+}
+
+.button {
+  position: absolute;
+  transform: translateY(-50%);
+  top: 50%;
+
+  &:disabled {
+    display: none;
+  }
+}
+
+.left {
+  left: -80px;
+}
+
+.right {
+  right: -80px;
+}
+
+.cardList {
+  display: flex;
+  flex-wrap: nowrap;
+  transition: transform 0.3s ease-in-out;
+}
+
+.card {
+  width: 25%;
+  flex: 0 0 300px;
+  padding: 0 12px;
+}
+
+@media screen and (max-width: 1199px) {
+  .button {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .card {
+    padding: 0 4px;
+    flex: 0 0 160px;
+  }
+}

--- a/src/features/support/index.jsx
+++ b/src/features/support/index.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import useSupportStore from './useSupportStore';
+import CardList from './CardList';
+import styles from './index.module.scss';
+
+const Support = () => {
+  const { supports, isLoading, error, fetchSupports } = useSupportStore();
+
+  useEffect(() => {
+    fetchSupports();
+  }, [fetchSupports]);
+
+  if (isLoading) return <p className={styles.loading}>Loading...</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  return <CardList supports={supports} />;
+};
+
+export default Support;

--- a/src/features/support/index.module.scss
+++ b/src/features/support/index.module.scss
@@ -1,0 +1,3 @@
+.loading {
+  color: white;
+}

--- a/src/features/support/useCarouselStore.js
+++ b/src/features/support/useCarouselStore.js
@@ -1,0 +1,20 @@
+import { create } from 'zustand';
+
+const useCarouselStore = create((set) => ({
+  currentIndex: 0,
+  slidesToShow: 4,
+  translateX: 0,
+  startX: 0,
+  initialPosition: 0,
+  isDragging: false,
+  itemWidth: 300,
+  setCurrentIndex: (index) => set({ currentIndex: index }),
+  setSlidesToShow: (value) => set({ slidesToShow: value }),
+  setTranslateX: (value) => set({ translateX: value }),
+  setStartX: (value) => set({ startX: value }),
+  setInitialPosition: (value) => set({ initialPosition: value }),
+  setIsDragging: (value) => set({ isDragging: value }),
+  setItemWidth: (width) => set({ itemWidth: width }),
+}));
+
+export default useCarouselStore;

--- a/src/features/support/useSupportStore.js
+++ b/src/features/support/useSupportStore.js
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import fetchData from '@/shared/api/fetchData';
+import { URL_DONATIONS } from '@/shared/constant/url';
+
+const useSupportStore = create((set) => ({
+  supports: [],
+  isLoading: false,
+  error: null,
+  fetchSupports: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const { data } = await fetchData(URL_DONATIONS);
+      set({ supports: data.list });
+    } catch (error) {
+      set({ error: error.message });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+
+export default useSupportStore;


### PR DESCRIPTION
## 요구사항
- [x] PC에서 후원을 기다리는 조공 리스트는 좌/우측 버튼 클릭 시 다음 순서의 조공 카드들이 보입니다.
- [x] PC에서 후원을 기다리는 조공 리스트 첫 순서일 때는 좌측 버튼이 보이지 않고, 마지막 순서일 때는 우측 버튼이 보이지 않습니다.
- [x] Tablet에서 후원을 기다리는 조공 리스트 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
- [x] Mobile에서 후원을 기다리는 조공 리스트 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
- [x] 캐러셀 구현

## 이슈
close #11

## 스크린샷 
![image](https://github.com/user-attachments/assets/b0c29064-f35d-4e2d-84e6-83b3552cca64)
![제목 없는 동영상 - Clipchamp로 제작 (1)](https://github.com/user-attachments/assets/a5085d9c-7e83-48b8-82ca-3df3ae8ec050)
