### PR TITLE
feat: create-support 페이지 api 구현

### DIFF
--- a/src/features/createsupport/CreateSupportForm.jsx
+++ b/src/features/createsupport/CreateSupportForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import Button from '@/shared/ui/Button';
 import { IDOL_EX } from '@/shared/constant/QUESTIONS';
@@ -25,11 +25,7 @@ const CreateSupportForm = () => {
     targetDonation: true,
   });
 
-  const { postSupport } = useFormStore();
-
-  const handelIdolIdChange = () => {
-    setIdolId(3731); // POST 테스트용: 장원영 id값
-  };
+  const { newId, getIdolId, postSupport } = useFormStore();
 
   const handleGenderChange = (e) => {
     setGender(e.target.value);
@@ -51,12 +47,26 @@ const CreateSupportForm = () => {
 
   const handleMemberChange = (e) => {
     setMember(e.target.value);
-    handelIdolIdChange();
+
     setIsValid((prevValues) => ({
       ...prevValues,
       idolId: true,
     }));
   };
+
+  useEffect(() => {
+    console.log('useEffect 동작: ', gender, group, member);
+    if (
+      gender !== IDOL_EX.GENDER &&
+      group !== IDOL_EX.GROUP &&
+      member !== IDOL_EX.MEMBER
+    ) {
+      console.log('status 조건만족: ', gender, group, member);
+      getIdolId(group, member);
+      console.log('newID값: ', newId);
+      setIdolId(newId);
+    }
+  }, [gender, group, member, getIdolId, newId]);
 
   const handleTitleChange = (e) => {
     if (e.target.value === '') {
@@ -141,14 +151,13 @@ const CreateSupportForm = () => {
       title: `${title}`,
       idolId: Number(`${idolId}`),
     };
-
+    // console.log('post: ', result);
     postSupport(result);
   };
 
   const handleCantSubmit = (e) => {
     e.preventDefault();
-    // 제출 막았을때 동작 추가할건지
-    console.log('message: Cant Submit (Invalid Input)');
+    // console.log('message: Cant Submit (Invalid Input)');
   };
 
   const handleReset = () => {
@@ -182,12 +191,11 @@ const CreateSupportForm = () => {
         <QuestionIdol
           data="idol"
           isValid
-          value={{ gender, group, member, idolId }}
+          value={{ gender, group, member }}
           handleValueChange={{
             handleGenderChange,
             handleGroupChange,
             handleMemberChange,
-            handelIdolIdChange,
           }}
         />
         <Question

--- a/src/features/createsupport/CreateSupportForm.jsx
+++ b/src/features/createsupport/CreateSupportForm.jsx
@@ -6,6 +6,7 @@ import styles from './CreateSupportForm.module.scss';
 import Question from './Question';
 import QuestionIdol from './QuestionIdol';
 import QuestionDate from './QuestionDate';
+import useFormStore from './useFormStore';
 
 const CreateSupportForm = () => {
   const [gender, setGender] = useState(`${IDOL_EX.GENDER}`);
@@ -24,9 +25,10 @@ const CreateSupportForm = () => {
     targetDonation: true,
   });
 
+  const { postSupport } = useFormStore();
+
   const handelIdolIdChange = () => {
-    // group이랑 member 값으로 api 요청, id 세팅하기
-    setIdolId(1111);
+    setIdolId(3731); // POST 테스트용: 장원영 id값
   };
 
   const handleGenderChange = (e) => {
@@ -129,22 +131,24 @@ const CreateSupportForm = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
 
+    const formattedDeadline = dayjs(deadline).format();
+    const formattedDonation = targetDonation.replaceAll(',', '');
+
     const result = {
-      deadline: { deadline },
-      targetDonation: { targetDonation },
-      subtitle: { subtitle },
-      title: { title },
-      idolId: { idolId },
+      deadline: `${formattedDeadline}`,
+      targetDonation: Number(`${formattedDonation}`),
+      subtitle: `${subtitle}`,
+      title: `${title}`,
+      idolId: Number(`${idolId}`),
     };
-    // 변경 예정
-    // POST 보내기, 통합 fetch 이용
-    // console.log(result);
+
+    postSupport(result);
   };
 
   const handleCantSubmit = (e) => {
     e.preventDefault();
     // 제출 막았을때 동작 추가할건지
-    // console.log('message: Cant Submit (Invalid Input)');
+    console.log('message: Cant Submit (Invalid Input)');
   };
 
   const handleReset = () => {
@@ -178,11 +182,12 @@ const CreateSupportForm = () => {
         <QuestionIdol
           data="idol"
           isValid
-          value={{ gender, group, member }}
+          value={{ gender, group, member, idolId }}
           handleValueChange={{
             handleGenderChange,
             handleGroupChange,
             handleMemberChange,
+            handelIdolIdChange,
           }}
         />
         <Question

--- a/src/features/createsupport/QuestionIdol.jsx
+++ b/src/features/createsupport/QuestionIdol.jsx
@@ -1,25 +1,9 @@
+import { useEffect } from 'react';
 import { QUESTIONS, IDOL_EX } from '@/shared/constant/QUESTIONS';
 import styles from './Question.module.scss';
 import Dropdown from './Dropdown';
-
-// 데이터구조(api 개발 후 교체 예정)
-const GENDER = ['남', '여'];
-const GROUP = {
-  성별: [],
-  여: ['아이브', '뉴진스', '레드벨벳', '엔믹스', '트와이스'],
-  남: ['방탄소년단', '세븐틴', '스트레이키즈'],
-};
-const MEMBER = {
-  그룹명: [],
-  뉴진스: ['민지', '혜인', '하니'],
-  아이브: ['가을', '유진', '원영'],
-  레드벨벳: ['아이린', '슬기', '조이'],
-  엔믹스: ['해원'],
-  트와이스: ['나연', '정연'],
-  방탄소년단: ['RM', '진'],
-  세븐틴: ['에스쿱스', '정한', '조슈아'],
-  스트레이키즈: ['필릭스'],
-};
+import useFormStore from './useFormStore';
+import processIdols from './processIdols';
 
 const QuestionIdol = ({ data, value, handleValueChange }) => {
   const { gender, group, member } = value;
@@ -28,27 +12,45 @@ const QuestionIdol = ({ data, value, handleValueChange }) => {
 
   const questionQuery = data.toUpperCase();
 
+  const { idols, isLoading, error, fetchIdols } = useFormStore();
+
+  useEffect(() => {
+    fetchIdols();
+  }, [fetchIdols]);
+
+  // console.log('fetchIdols 완료: ', idols);
+
+  if (isLoading) return <p className={styles.loading}>Loading...</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  const { genderList, groupList, memberList } = processIdols(idols);
+
+  // console.log('데이터 프로세싱 완료');
+  // console.log('genderList: ', genderList);
+  // console.log('groupList: ', groupList);
+  // console.log('memberList: ', memberList);
+
   return (
     <div className={styles.question}>
       <p className={styles.questionText}>{QUESTIONS[questionQuery]}</p>
       <div className={styles.idolquestion}>
         <Dropdown
           className={styles.dropdown}
-          list={GENDER}
+          list={genderList}
           selected={gender}
           handleSelect={handleGenderChange}
           initial={IDOL_EX.GENDER}
         />
         <Dropdown
           className={styles.dropdown}
-          list={GROUP[gender]}
+          list={groupList[gender]}
           selected={group}
           handleSelect={handleGroupChange}
           initial={IDOL_EX.GROUP}
         />
         <Dropdown
           className={styles.dropdown}
-          list={MEMBER[group]}
+          list={memberList[group]}
           selected={member}
           handleSelect={handleMemberChange}
           initial={IDOL_EX.MEMBER}

--- a/src/features/createsupport/processIdols.js
+++ b/src/features/createsupport/processIdols.js
@@ -1,0 +1,40 @@
+const processIdols = (list) => {
+  const genderList = ['남', '여'];
+  const groupList = {
+    성별: [],
+    남: [],
+    여: [],
+  };
+  const memberList = {
+    그룹명: [],
+  };
+
+  list.forEach((el) => {
+    if (el.gender === 'male') {
+      if (groupList['남'].indexOf(`${el.group}`) < 0) {
+        groupList['남'].push(el.group);
+        memberList[`${el.group}`] = [];
+        memberList[`${el.group}`].push(`${el.name}`);
+      } else if (groupList['남'].indexOf(`${el.group}`) >= 0) {
+        if (memberList[`${el.group}`].indexOf(`${el.name}`) < 0)
+          memberList[`${el.group}`].push(`${el.name}`);
+      }
+    } else if (el.gender === 'female') {
+      if (groupList['여'].indexOf(`${el.group}`) < 0) {
+        groupList['여'].push(el.group);
+        memberList[`${el.group}`] = [];
+        memberList[`${el.group}`].push(`${el.name}`);
+      } else if (groupList['여'].indexOf(`${el.group}`) >= 0) {
+        if (memberList[`${el.group}`].indexOf(`${el.name}`) < 0)
+          memberList[`${el.group}`].push(`${el.name}`);
+      }
+    }
+  });
+
+  Object.keys(groupList).map((key) => groupList[`${key}`].sort());
+  Object.keys(memberList).map((key) => memberList[`${key}`].sort());
+
+  return { genderList, groupList, memberList };
+};
+
+export default processIdols;

--- a/src/features/createsupport/useFormStore.js
+++ b/src/features/createsupport/useFormStore.js
@@ -40,6 +40,26 @@ const useFormStore = create((set) => ({
       set({ isPosting: false });
     }
   },
+
+  getIdolId: async (group, member) => {
+    set({ isLoading: true, error: null });
+
+    const name = member;
+    const url = URL_IDOLS;
+    const query = {
+      keyword: `${name}`,
+    };
+
+    try {
+      const { data: selectedIdol } = await fetchData(url, query);
+      // console.log('selected data: ', selectedIdol);
+      set({ newId: selectedIdol?.list[0].id || 0 });
+    } catch (error) {
+      set({ error: error.message });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
 }));
 
 export default useFormStore;

--- a/src/features/createsupport/useFormStore.js
+++ b/src/features/createsupport/useFormStore.js
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import fetchData from '@/shared/api/fetchData';
+import { URL_IDOLS } from '@/shared/constant/url';
+
+const useFormStore = create((set) => ({
+  idols: [],
+  newId: 0,
+  isLoading: false,
+  error: null,
+
+  fetchIdols: async () => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const { data: AllIdolData } = await fetchData(URL_IDOLS, {
+        pageSize: 1000,
+      });
+      set({ idols: AllIdolData?.list || [] });
+    } catch (error) {
+      set({ error: error.message });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+
+export default useFormStore;

--- a/src/features/createsupport/useFormStore.js
+++ b/src/features/createsupport/useFormStore.js
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
 import fetchData from '@/shared/api/fetchData';
-import { URL_IDOLS } from '@/shared/constant/url';
+import { URL_IDOLS, URL_DONATIONS } from '@/shared/constant/url';
 
 const useFormStore = create((set) => ({
   idols: [],
   newId: 0,
   isLoading: false,
+  isPosting: false,
   error: null,
 
   fetchIdols: async () => {
@@ -20,6 +21,23 @@ const useFormStore = create((set) => ({
       set({ error: error.message });
     } finally {
       set({ isLoading: false });
+    }
+  },
+
+  postSupport: async (result) => {
+    set({ isPosting: true, error: null });
+
+    const url = URL_DONATIONS;
+    const method = 'POST';
+    const body = result;
+
+    try {
+      const { data: response } = await fetchData(url, {}, method, body);
+      // console.log('post의 리스폰스: ', response);
+    } catch (error) {
+      set({ error: error.message });
+    } finally {
+      set({ isPosting: false });
     }
   },
 }));


### PR DESCRIPTION
## 요구사항
- - - 
- [x] 페이지 접속시 전체 아이돌 데이터를 api로 받아와서 적절한 형태로 가공함
- [x] gender, group, member 값으로 idol id 받아오는 api
- [x] post api

## 이슈
- - - 
